### PR TITLE
Use win-clipboard for setting HTML/text clipboard

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,3 +6,5 @@ src/**
 **/*.map
 .gitignore
 tsconfig.json
+appveyor.yml
+buildNotes.md

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ As for programmer I prefer to write stuff quickly in markdown. Be it email, docs
 
 ## Known Issues
 
-* Currently it works only on Windows, using powershell cmd. **Pull requests are welcome.**
+* Currently it works only on Windows, since it uses [win-clipboard](https://github.com/mlewand/win-clipboard). **Pull requests are welcome.**
 * Doesn't put plain text, just HTML mime type.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ Renders selected markdown into rich text in your clipboard, so that you can past
 
 As for programmer I prefer to write stuff quickly in markdown. Be it email, docs, specs - you name it. Some apps, e.g. my e-mail client doesn't support markdown and are just PITA to use, so I actually create a msg in vscode and then paste it into the email.
 
+## Major Changes
+
+### 0.0.2
+
+This extension switched to [win-clipboard](https://github.com/mlewand/win-clipboard) library, which uses [native module addons that are currently not supported by VSCode](https://github.com/Microsoft/vscode/issues/658). I have included prebuilt binaries for the `x64` architecture, and for the time being I have no other workaround for that.
+
 ## Known Issues
 
 * Currently it works only on Windows, since it uses [win-clipboard](https://github.com/mlewand/win-clipboard). **Pull requests are welcome.**
-* Doesn't put plain text, just HTML mime type.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 
 install:
   - ps: Install-Product node ''
-  - npm install -g npm --silent --quiet
   - npm install --silent --quiet
 
 platform:

--- a/buildNotes.md
+++ b/buildNotes.md
@@ -1,0 +1,25 @@
+# Building
+
+After fixing [#1](https://github.com/mlewand/vscode-markdown-to-clipboard/issues/1) building got very tricky, follow these steps to build extension (for targeting VSCode 1.18.1 64bit):
+
+```bash
+# Electron's version.
+export npm_config_target=1.7.9
+# The architecture of Electron, can be ia32 or x64.
+export npm_config_arch=x64
+export npm_config_target_arch=x64
+# Download headers for Electron.
+export npm_config_disturl=https://atom.io/download/electron
+# Tell node-pre-gyp that we are building for Electron.
+export npm_config_runtime=electron
+# Tell node-pre-gyp to build module from source code.
+export npm_config_build_from_source=true
+# Install all dependencies, and store cache to ~/.electron-gyp.
+HOME=~/.electron-gyp npm install
+```
+
+References:
+
+* https://github.com/Microsoft/vscode/issues/658
+* https://github.com/electron/electron/blob/master/docs/tutorial/using-native-node-modules.md
+* https://github.com/bartosz-antosik/vscode-spellright/issues/3

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "vscode-test-content": "^1.2.0"
   },
   "dependencies": {
-    "any-shell-escape": "^0.1.1",
+    "html-to-text": "^3.3.0",
     "marked": "^0.3.6",
-    "node-powershell": "^3.1.1"
+    "win-clipboard": "0.0.5"
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as marked from 'marked';
-import * as nodePowershell from 'node-powershell';
-import * as escape from 'any-shell-escape';
+import * as winClipboard from 'win-clipboard';
+import * as htmlToText from 'html-to-text';
 
 export default {
 	copyToClipboard: function( editor: vscode.TextEditor, edit: vscode.TextEditorEdit ) {
@@ -11,15 +11,12 @@ export default {
 		this._saveToClipboard( marked( mdSource ) );
 	},
 
+	// Store reference to winClipboard to allow stubbing in unit tests.
+	_winClipboard: winClipboard,
+
 	_saveToClipboard: function( html: string ) {
-		let ps = new nodePowershell( {
-			executionPolicy: 'Bypass',
-			noProfile: true,
-			debugMsg: false
-		} );
-
-		ps.addCommand( 'Set-Clipboard -AsHtml -Value ' + escape( html.replace( /\r?\n/g, '' ) ) );
-
-		return ps.invoke();
+		this._winClipboard.clear();
+		this._winClipboard.setText( htmlToText.fromString( html, { wordwrap: false } ) );
+		this._winClipboard.setHtml( html );
 	}
 };

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -10,7 +10,6 @@ chai.use( sinonChai );
 
 const expect = chai.expect;
 
-// Defines a Mocha test suite to group tests of similar kind together
 describe( 'copyToClipboard command', () => {
     let saveToClipboardStub;
 
@@ -46,5 +45,40 @@ describe( 'copyToClipboard command', () => {
                 commands.copyToClipboard( textEditor, null );
                 expect( saveToClipboardStub ).to.be.calledOnce.and.calledWith( '<p>oo\nbar</p>\n' );
             } );
+    } );
+} );
+
+describe( '_saveToClipboard method', () => {
+    before(() => {
+        sinon.stub( commands._winClipboard, 'clear' );
+        sinon.stub( commands._winClipboard, 'setText' );
+        sinon.stub( commands._winClipboard, 'setHtml' );
+    } );
+
+    beforeEach(() => {
+        commands._winClipboard.clear.reset();
+        commands._winClipboard.setText.reset();
+        commands._winClipboard.setHtml.reset();
+    } );
+
+    after(() => {
+        commands._winClipboard.clear.restore();
+        commands._winClipboard.setText.restore();
+        commands._winClipboard.setHtml.restore();
+    } );
+
+    it( 'Clears existing clipboard data', () => {
+        commands._saveToClipboard( 'foo' );
+        expect( commands._winClipboard.clear ).to.be.calledOnce;
+    } );
+
+    it( 'Sets HTML clipboard', () => {
+        commands._saveToClipboard( 'foo <b>bar</b> baz' );
+        expect( commands._winClipboard.setHtml ).to.be.calledOnce.and.calledWith( 'foo <b>bar</b> baz' );
+    } );
+
+    it( 'Also sets plain text representation of HTML', () => {
+        commands._saveToClipboard( 'foo <b>bar</b> baz' );
+        expect( commands._winClipboard.setText ).to.be.calledOnce.and.calledWith( 'foo bar baz' );
     } );
 } );


### PR DESCRIPTION
This enhancement fixes 2 main prolems:

* #1 - Unicode and emojis produce artifacts
* #2 - No plain text set during copy

However this library uses native C++ addons, which are not supported by VSCode extensions ATM (Microsoft/vscode#658).

More info on this change in README.md.

Closes #1, #2.